### PR TITLE
[fix] add cycle-import-check binary alias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "glob": "^8.1.0"
       },
       "bin": {
+        "cycle-import-check": "lib/cli.js",
         "cycle-import-scan": "lib/cli.js",
         "iscan": "lib/cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "bin": {
     "iscan": "lib/cli.js",
+    "cycle-import-check": "lib/cli.js",
     "cycle-import-scan": "lib/cli.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Describe your changes
The documentation of the package, its name, refer to the executable name that is not present. This adds it back.

At the same time removing the one used in the meantime would be a breaking change, so keep it in.

## Checklist before requesting a review

- [x] Project license confirmed
- [x] Unit-test added & passed at local development environment
- [x] All CI check passed
